### PR TITLE
Fixes for Crystsal 0.31.0

### DIFF
--- a/src/cadmium/summarizer/luhn.cr
+++ b/src/cadmium/summarizer/luhn.cr
@@ -37,7 +37,7 @@ module Cadmium
         (number_of_normalized_terms*number_of_normalized_terms) // window_size
       end
 
-      private def select_sentences(text, max_num_sentences)
+      private def select_sentences(text, max_num_sentences) : Array(String)
         normalized_terms_ratio = normalized_terms_ratio(text)
         sentences = Cadmium::Util::Sentence.sentences(text)
         sentences.sort_by! { |sentence| -sentence_rating(sentence, normalized_terms_ratio) } # This could be improved, performance wise.

--- a/src/cadmium/summarizer/luhn.cr
+++ b/src/cadmium/summarizer/luhn.cr
@@ -34,7 +34,7 @@ module Cadmium
         window_size = window_size(terms_in_sentence, normalized_terms)
         return 0 if window_size <= 0
         number_of_normalized_terms = terms_in_sentence.count { |term| normalized_terms.includes?(term) }
-        (number_of_normalized_terms*number_of_normalized_terms) / window_size
+        (number_of_normalized_terms*number_of_normalized_terms) // window_size
       end
 
       private def select_sentences(text, max_num_sentences)


### PR DESCRIPTION
The / operator was changed to return floats: crystal-lang/crystal#8120. This change preserves previous behaviour (floor).

Also fixed a warning.